### PR TITLE
fix memory leak

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2107,7 +2107,7 @@ class Level implements ChunkManager, Metadatable{
 			unset($this->players[$entity->getId()]);
 			//$this->everyoneSleeping();
 		}else{
-			$entity->kill();
+			$entity->close();
 		}
 
 		unset($this->entities[$entity->getId()]);


### PR DESCRIPTION
courtesy of @dktapps

explanation:

**Before patch**:
Chunk is unloaded and saved. All entities on the chunk are saved. Level::removeEntity is called on all entities in that chunk to remove them.
Level::removeEntity kills non-player entities. Result is items and XP being spawned in an unloaded chunk.
Movement updates to these entitities (falling checks etc.) trigger requests to the blocks around the entities. Because the entities are in unloaded chunks, these requests cause the chunks to be reloaded. When the chunk is reloaded, the saved entities are spawned again.
Process repeats, leaking more and more entities until memory limit is exhausted.

**After patch**:
Chunk is unloaded and saved. All entities on the chunk are saved. Level::removeEntity is called on all entities in that chunk to remove them.
Because Level::removeEntity now uses close() instead of kill(), no items or exp are dropped, which prevents the leak from beginning.

also see https://github.com/Nukkit/Nukkit/pull/894, https://github.com/iTXTech/Genisys/issues/194 and https://github.com/iTXTech/Genisys/commit/e98738ca2d104ecc9e38436949c6b0854db20474