### PR TITLE
Fixed Level->unloadQueue not being initialized

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -169,7 +169,7 @@ class Level implements ChunkManager, Metadatable{
 	protected $usedChunks = [];
 
 	/** @var FullChunk[]|Chunk[] */
-	protected $unloadQueue;
+	protected $unloadQueue = [];
 
 	protected $time;
 	public $stopTime;


### PR DESCRIPTION
This bug causes a constant spam of warnings on PHP 7.2
```
Warning: count(): Parameter must be an array or an object that implements Countable
```

This issue doesn't affect anything functionally.