### PR TITLE
Fixed #385

### DIFF
--- a/src/pocketmine/network/rcon/RCON.php
+++ b/src/pocketmine/network/rcon/RCON.php
@@ -71,7 +71,7 @@ class RCON{
 		for($n = 0; $n < $this->threads; ++$n){
 			$this->workers[$n]->close();
 			usleep(50000);
-			$this->workers[$n]->kill();
+			$this->workers[$n]->quit();
 		}
 		@socket_close($this->socket);
 		$this->threads = 0;


### PR DESCRIPTION
\Thread::kill was removed on pthreads 3 (PHP 7), to remove the thread we can use pocketmine\Thread::quit()