### PR TITLE
Fixed crashing when stopping server

### DIFF
--- a/src/pocketmine/network/rcon/RCONInstance.php
+++ b/src/pocketmine/network/rcon/RCONInstance.php
@@ -81,6 +81,9 @@ class RCONInstance extends Thread{
 	public function close(){
 		$this->stop = true;
 	}
+	public function kill(){
+		$this->stop = true;
+	}
 
 	public function run(){
 


### PR DESCRIPTION
If in server.properties option rcon.enable equals TRUE, the server will crash and cant stop cause it cant find kill() method. Now i added it and server never crashing when trying to kill RCON