### PR TITLE
Remove unnecessary startup checks. Close #421

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -396,10 +396,6 @@ namespace pocketmine {
 		++$errors;
 	}
 
-	if(!extension_loaded("uopz")){
-		//$logger->notice("Couldn't find the uopz extension. Some functions may be limited");
-	}
-
 	if(extension_loaded("pocketmine")){
 		if(version_compare(phpversion("pocketmine"), "0.0.1") < 0){
 			$logger->critical("You have the native PocketMine extension, but your version is lower than 0.0.1.");
@@ -417,11 +413,6 @@ namespace pocketmine {
 
 	if(!extension_loaded("yaml")){
 		$logger->critical("Unable to find the YAML extension.");
-		++$errors;
-	}
-
-	if(!extension_loaded("sqlite3")){
-		$logger->critical("Unable to find the SQLite3 extension.");
 		++$errors;
 	}
 


### PR DESCRIPTION
This PR removes SQLite3 and UOPZ checks as they are unnecessary. SQLite3 is not used anymore in PocketMine and only causes issues to people without it compiled in their bin folder. UOPZ is no longer needed and is even commented out, which shows that it just causes more problems. 