### PR TITLE
fix inv transaction bug on win10 inv

### DIFF
--- a/src/pocketmine/inventory/win10/PlayerInventoryData.php
+++ b/src/pocketmine/inventory/win10/PlayerInventoryData.php
@@ -237,7 +237,17 @@ class PlayerInventoryData {
 					$trGroup->sendInventories();
 				}
 				$this->resetData();
+			} else {
+				$player = $this->inventory->getHolder();
+				foreach ($this->transactionDataList as $transactionData) {
+					$inventory = $transactionData->getInventory();
+					if ($inventory instanceof PlayerInventory) {
+						$inventory->sendArmorContents($player);
+					}
+					$inventory->sendContents($player);
+				}
 			}
+			$this->resetData();
 		} catch (\Exception $e) {
 //			var_dump('transactions rollback');
 			// resend inventories


### PR DESCRIPTION
i am span transaction shop bedwars on my plugin and lbsg bedwars
it bug on spam transaction(InventoryTransactionEvent is Cancelled) on win10
*i am test this it work