### PR TITLE
SignEntity: Fixed possible client crash

### DIFF
--- a/src/pocketmine/tile/SignEntity.php
+++ b/src/pocketmine/tile/SignEntity.php
@@ -63,7 +63,7 @@ class SignEntity extends Entity {
 	public function despawnFrom(Player $player) {
 		if (isset($this->hasSpawned[$player->getId()])) {
 			unset($this->hasSpawned[$player->getId()]);
-			if ($player->getPlayerProtocol() != Info::PROTOCOL_260) {
+			if ($player->getOriginalProtocol() != Info::PROTOCOL_260) {
 				return;
 			}
 			$pk = new RemoveEntityPacket();


### PR DESCRIPTION
If the entity disappears, if the playerProtocol matches 260, but the originalProtocol is different from it, the game will crash