### PR TITLE
Allow 128x128 player skins when joining

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3331,7 +3331,7 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 			return;
 		}
 
-		if (strlen($this->skin) !== 64 * 32 * 4 && strlen($this->skin) !== 64 * 64 * 4) {
+		if (strlen($this->skin) !== 64 * 32 * 4 && strlen($this->skin) !== 64 * 64 * 4 && strlen($this->skin) !== 128 * 128 * 4) {
 			$this->close("", "Invalid skin.", false);
 			return;
 		}


### PR DESCRIPTION
Players using a 128x128 skin can't join the server because the server thinks they are using an invalid skin.

This behaviour isn't consistent when changing the skin in-game, so this pr aims to allow 128x128 skins when entering the server, too.