### PR TITLE
Add TextFormat::colorize

### DIFF
--- a/src/pocketmine/utils/TextFormat.php
+++ b/src/pocketmine/utils/TextFormat.php
@@ -83,6 +83,10 @@ abstract class TextFormat{
 		return str_replace("\x1b", "", preg_replace("/\x1b[\\(\\][[0-9;\\[\\(]+[Bm]/", "", $string));
 	}
 
+	public static function colorize(string $string, string $placeholder = "&") : string{
+		return preg_replace('/' . preg_quote($placeholder, "/") . '([0-9a-fk-or])/u', TextFormat::ESCAPE . '$1', $string);
+	}
+
 	/**
 	 * Returns an JSON-formatted string with colors/markup
 	 *


### PR DESCRIPTION
Some plugins use TextFormat::colorize to use colours and steadfast doesn't support it.So I added this from latest pocketmine and different colours work as you can see on this plugin.
![screenshot_2018-08-02-13-55-57-039_net fengberd minecraftpe_server](https://user-images.githubusercontent.com/22281205/43579775-e0053bee-965b-11e8-8ecd-10b79d063e8c.png)
