### PR TITLE
Getter and setter addition for saturation. Enchanted golden apple works

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1607,6 +1607,7 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer {
         }
     }
 	
+	//TODO: Rewriting food system
 	protected static $foodData = [
 		Item::APPLE => ['food' => 4, 'saturation' => 2.4],
 		Item::BAKED_POTATO => ['food' => 5, 'saturation' => 6],
@@ -1624,6 +1625,7 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer {
 		Item::COOKED_SALMON => ['food' => 6, 'saturation' => 9.6],
 		Item::COOKIE => ['food' => 2, 'saturation' => 0.4],
 		Item::GOLDEN_APPLE => ['food' => 4, 'saturation' => 9.6],
+		Item::ENCHANTNED_GOLDEN_APPLE => ['food' => 4, 'saturation' => 9.6],
 		Item::GOLDEN_CARROT => ['food' => 6, 'saturation' => 14.4],
 		Item::MELON => ['food' => 2, 'saturation' => 1.2],
 		Item::MUSHROOM_STEW => ['food' => 6, 'saturation' => 7.2],
@@ -2881,6 +2883,16 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer {
 
 	public function getFood() {
 		return $this->foodLevel;
+	}
+	
+	public functon getSaturation()
+	{
+		return $this->satuartion;
+	}
+	
+	public function setSaturation($sat)
+	{
+		$this->saturation = $sat;
 	}
 
 	public function subtractFood($amount){


### PR DESCRIPTION
This commit adds 2 get|set methods:
    Player::getSaturation();
    Player::setSaturation($val);

and makes Enchanted Golden Apples are workable.