### PR TITLE
Hotfix server vulnerability, it leads to crash RakLib

### DIFF
--- a/src/raklib/server/SessionManager.php
+++ b/src/raklib/server/SessionManager.php
@@ -214,7 +214,11 @@ class SessionManager{
 			if ($session->isEncryptEnable()) {
 				$buff = $session->getDecrypt($buff);
 			}
-			$decoded = zlib_decode($buff);
+            try{
+                $decoded = zlib_decode($buff, 1024 * 1024 * 2); //Max 2MB
+            }catch(\ErrorException $e){ //zlib decode error
+                $decoded = "";
+            }
 			$stream = new BinaryStream($decoded);
 			$length = strlen($decoded);
 			static $spamPacket = "\x39\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";


### PR DESCRIPTION
This foolishness (check) was made by the developer of SteadFast2, attacking without creating a session, we just get a crash racklib and an error about an exception not captured.
![GDrs7_m9ytg](https://user-images.githubusercontent.com/47471825/82284810-599eda80-99b3-11ea-9f28-dde0afdd01b8.jpg)
