### PR TITLE
Server: fixed not being able to deop players whose names were added to ops.txt with uppercase letters in them

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1368,8 +1368,13 @@ class Server{
 	 * @param string $name
 	 */
 	public function removeOp($name){
-		$this->operators->remove(strtolower($name));
-
+		$lowercaseName = strtolower($name);
+		foreach($this->operators->getAll() as $operatorName => $_){
+			$operatorName = (string) $operatorName;
+			if($lowercaseName === strtolower($operatorName)){
+				$this->operators->remove($operatorName);
+			}
+		}
 		if(($player = $this->getPlayerExact($name)) instanceof Player){
 			$player->recalculatePermissions();
 		}


### PR DESCRIPTION
Inability to de-op players if listed in ops.txt with non-lowercase letters

same as https://github.com/iTXTech/Genisys/issues/1188